### PR TITLE
Improves support for specialversion

### DIFF
--- a/Versatile.Core/Grammar.cs
+++ b/Versatile.Core/Grammar.cs
@@ -143,6 +143,22 @@ namespace Versatile
             }
         }
 
+        public static Parser<char> AnyIdentifierChar
+        {
+            get
+            {
+                return Parse.Digit.Or(NonDigit).Or(Dot).Or(Dash);
+            }
+        }
+
+        public static Parser<string> AnyIdentifier
+        {
+            get
+            {
+                return AnyIdentifierChar.AtLeastOnce().Token().Text();
+            }
+        }
+
         public static Parser<string> XIdentifier
         {
             get

--- a/Versatile.Core/NuGet/Grammar.cs
+++ b/Versatile.Core/NuGet/Grammar.cs
@@ -46,6 +46,14 @@ namespace Versatile
                 }
             }
 
+            public static Parser<char> AnyChar
+            {
+                get
+                {
+                    return Sprache.Parse.AnyChar;
+                }
+            }
+
             public static Parser<int> Build
             {
                 get
@@ -82,10 +90,9 @@ namespace Versatile
             {
                 get
                 {
-
-                    return
-                        from dot in Sprache.Parse.Char('-')
-                        from s in Special
+                    return 
+                        from dash in Sprache.Parse.Char('-')
+                        from s in AnyIdentifier
                         select s;
                 }
             }
@@ -110,7 +117,7 @@ namespace Versatile
                             else
                             {
                                 return new NuGetv2(v[0] == "" ? 0 : Int32.Parse(v[0]), v[1] == "" ? 0 : Int32.Parse(v[1]), v[2] == "" ? 0 : Int32.Parse(v[2]),
-                                    v[3] == "" ? 0 : Int32.Parse(v[3]));
+                                    v[3] == "" ? 0 : Int32.Parse(v[3]), v[4]);
                             }
                         });
                 }

--- a/Versatile.Core/NuGet/Grammar.cs
+++ b/Versatile.Core/NuGet/Grammar.cs
@@ -14,7 +14,7 @@ namespace Versatile
         public class Grammar : Grammar<NuGetv2>
         {
         
-            public static new Parser<char> NonDigit
+            public new static Parser<char> NonDigit
             {
                 get
                 {

--- a/Versatile.Core/NuGet/NuGetv2.cs
+++ b/Versatile.Core/NuGet/NuGetv2.cs
@@ -37,8 +37,8 @@ namespace Versatile
     public sealed partial class NuGetv2 : Version, IVersionFactory<NuGetv2>, IComparable, IComparable<NuGetv2>, IEquatable<NuGetv2>
     {
         private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
-        private static readonly Regex _NuGetRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
-        private static readonly Regex _strictNuGetRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
+        private static readonly Regex _NuGetRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>\-[a-z][0-9a-z\-\.]*)?$", _flags);
+        private static readonly Regex _strictNuGetRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>\-[a-z][0-9a-z\-\.]*)?$", _flags);
         private readonly string _originalString;
         private string _normalizedVersionString;
 
@@ -263,7 +263,7 @@ namespace Versatile
             NuGetv2 semVer;
             if (!TryParse(version, out semVer))
             {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, "Invalid Version String", version), "version");
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, "Invalid Version String {0}", version), "version");
             }
             return semVer;
         }

--- a/Versatile.Core/NuGet/NuGetv2.cs
+++ b/Versatile.Core/NuGet/NuGetv2.cs
@@ -52,6 +52,12 @@ namespace Versatile
             
         }
 
+        public NuGetv2(int major, int minor, int build, int revision, string specialVersion)
+            : this(new System.Version(major, minor, build, revision), specialVersion)
+        {
+            this.Add(this.Major.ToString());
+        }
+
         public NuGetv2(int major, int minor, int build, int revision)
             : this(new System.Version(major, minor, build, revision))
         {

--- a/Versatile.Tests/NuGetv2/GrammarTests.cs
+++ b/Versatile.Tests/NuGetv2/GrammarTests.cs
@@ -14,18 +14,39 @@ namespace Versatile.Tests
         [Fact]
         public void GrammarCanParseVersion()
         {
+            NuGetv2 n;
             NuGetv2 f = NuGetv2.Grammar.NuGetv2Version.Parse("3.2.5-foo");
             NuGetv2 f2 = NuGetv2.Grammar.NuGetv2Version.Parse("3.1.0.3-foo");
-            NuGetv2 n = NuGetv2.Parse("3.2.5-foo");
+            NuGetv2 f3 = NuGetv2.Grammar.NuGetv2Version.Parse("3.1.0.3-foo-bar");
+            NuGetv2 f4 = NuGetv2.Grammar.NuGetv2Version.Parse("3.1.0.3-foo-v1-20200911.23");
+            
+            n = NuGetv2.Parse("3.2.5-foo");
             Assert.Equal(n, NuGetv2.Grammar.NuGetv2Version.Parse("3.2.5-foo"));
-            Assert.Equal(n.Version.Major, 3);
-            Assert.Equal(n.SpecialVersion, "foo");
-            Assert.Equal(n.Version.Minor, 2);
-            Assert.Equal(n.Version.Build, 5);
+            Assert.Equal(3, n.Version.Major);
+            Assert.Equal(2, n.Version.Minor);
+            Assert.Equal(5, n.Version.Build);
+            Assert.Equal("foo", n.SpecialVersion);
+            
+            n = NuGetv2.Parse("1.2.3.4-foo-v1-20200911.23");
+            Assert.Equal(n, NuGetv2.Grammar.NuGetv2Version.Parse("1.2.3.4-foo-v1-20200911.23"));
+            Assert.Equal(1, n.Version.Major);
+            Assert.Equal(2, n.Version.Minor);
+            Assert.Equal(3, n.Version.Build);
+            Assert.Equal(3, n.Version.Build);
+            Assert.Equal("foo-v1-20200911.23", n.SpecialVersion);
+            
             n = NuGetv2.Grammar.NuGetv2Version.Parse("3.4.0199");
 
             //Assert.Throws<ParseException>(() => NuGetv2.Grammar.NuGetv2Version.Parse("A.2.3"));
             //Assert.Throws<ParseException>(() => NuGetv2.Grammar.NuGetv2Version.Parse("3.2.3.X"));
+        }
+
+        [Fact]
+        public void GrammarCanParseRange()
+        {
+            var re = NuGetv2.Grammar.Range.Parse("<1.2.3.4-foo-v1-20200911.23");
+            Assert.NotNull(re);
+            
         }
 
         [Fact]
@@ -52,34 +73,37 @@ namespace Versatile.Tests
             Assert.Equal(6, re.Version.Version.Minor);
             Assert.Equal(string.Empty, re.Version.SpecialVersion);
             Comparator<NuGetv2> c = NuGetv2.Grammar.OneSidedRange.Parse("<1.5.4").Last();
-            Assert.Equal(c.Operator, ExpressionType.LessThan);
-            Assert.Equal(c.Version.Version.Major, 1);
-            Assert.Equal(c.Version.Version.Minor, 5);
+            Assert.Equal(ExpressionType.LessThan, c.Operator);
+            Assert.Equal(1, c.Version.Version.Major);
+            Assert.Equal(5, c.Version.Version.Minor);
             c = NuGetv2.Grammar.OneSidedRange.Parse("<1.0").Last();
-            Assert.Equal(c.Operator, ExpressionType.LessThan);
-            Assert.Equal(c.Version.Version.Major, 1);
-            Assert.Equal(c.Version.Version.Minor, 0);
+            Assert.Equal(ExpressionType.LessThan, c.Operator );
+            Assert.Equal(1, c.Version.Version.Major);
+            Assert.Equal(0, c.Version.Version.Minor);
             c = NuGetv2.Grammar.OneSidedRange.Parse("<1.0.0-alpha").Last();
-            Assert.Equal(c.Operator, ExpressionType.LessThan);
-            Assert.Equal(c.Version.Version.Major, 1);
-            Assert.Equal(c.Version.Version.Minor, 0);
-            Assert.Equal(c.Version.SpecialVersion.ToString(), "alpha");
+            Assert.Equal(ExpressionType.LessThan, c.Operator);
+            Assert.Equal(1, c.Version.Version.Major);
+            Assert.Equal(0, c.Version.Version.Minor);
+            Assert.Equal("alpha", c.Version.SpecialVersion.ToString());
             c = NuGetv2.Grammar.OneSidedRange.Parse(">=0.0.0").Last();
             c = NuGetv2.Grammar.OneSidedRange.Parse("<3.4.0199").Last();
-
-            
+            c = NuGetv2.Grammar.OneSidedRange.Parse("<1.0.0-alpha-v1-20200911.23").Last();
+            Assert.Equal(ExpressionType.LessThan, c.Operator);
+            Assert.Equal(1, c.Version.Version.Major);
+            Assert.Equal(0, c.Version.Version.Minor);
+            Assert.Equal("alpha-v1-20200911.23", c.Version.SpecialVersion.ToString() );
         }
 
         [Fact]
         public void GrammarCanParseOpenBracketsOpenBrackets()
         {
             ComparatorSet<NuGetv2> cs = NuGetv2.Grammar.OpenBracketOpenBracketRange.Parse("(2.0, 3.1.0)");
-            Assert.Equal(cs.Count, 2);
-            Assert.Equal(cs[0].Operator, ExpressionType.GreaterThan);
-            Assert.Equal(cs[1].Operator, ExpressionType.LessThan);
+            Assert.Equal(2, cs.Count);
+            Assert.Equal(ExpressionType.GreaterThan, cs[0].Operator);
+            Assert.Equal(ExpressionType.LessThan, cs[1].Operator);
             cs = NuGetv2.Grammar.OpenBracketOpenBracketRange.Parse("(, 3.1)");
-            Assert.Equal(cs.Count, 2);
-            Assert.Equal(cs[0].Operator, ExpressionType.GreaterThan);
+            Assert.Equal(2, cs.Count);
+            Assert.Equal(ExpressionType.GreaterThan, cs[0].Operator);
         }
 
         [Fact]
@@ -87,11 +111,11 @@ namespace Versatile.Tests
         {
             ComparatorSet<NuGetv2> cs = NuGetv2.Grammar.OpenBracketClosedBracketRange.Parse("(2.3, 3.3.0-beta6]");
             Assert.Equal(cs.Count, 2);
-            Assert.Equal(cs[0].Operator, ExpressionType.GreaterThan);
-            Assert.Equal(cs[1].Operator, ExpressionType.LessThanOrEqual);
+            Assert.Equal(ExpressionType.GreaterThan, cs[0].Operator);
+            Assert.Equal(ExpressionType.LessThanOrEqual, cs[1].Operator);
             cs = NuGetv2.Grammar.OpenBracketClosedBracketRange.Parse("(, 3.1]");
-            Assert.Equal(cs.Count, 2);
-            Assert.Equal(cs[1].Operator, ExpressionType.LessThanOrEqual);
+            Assert.Equal(2, cs.Count);
+            Assert.Equal(ExpressionType.LessThanOrEqual, cs[1].Operator);
         }
     }
 }


### PR DESCRIPTION
I created this crude update to fix handling of version numbering containing multiple dashes.

This update supports:
* 1.0.0-rc-00260 (specialversion = "rc-00260")
* 2.0.0-umbraco-v8-20190325.23 (specialversion = "umbraco-v8-20190325.23")

This update does not support:
* 5.0.0.rc4.0

I also changed the argument order in the tests to match expected vs result.
